### PR TITLE
Path Resolution issue in postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "sequelize": "^6.3.5"
   },
   "scripts": {
-    "postinstall": "node ./postinstall.js --init-dir $INIT_CWD"
+    "postinstall": "node ./postinstall.js"
   },
   "repository": {
     "type": "git",

--- a/postinstall.js
+++ b/postinstall.js
@@ -2,11 +2,10 @@
 const fs = require('fs');
 const path = require('path');
 const LIBRARY_NAME = process.env.npm_package_name;
-const EXEC_DIR = process.argv.slice(2)[process.argv.slice(2).indexOf("--init-dir") + 1];
 
 const initEnv = async () => {
-  let envFileContents = fs.readFileSync(path.resolve(EXEC_DIR, `node_modules/${LIBRARY_NAME}/env.json`), 'utf8');
-  let projectEnvFileContents = fs.readFileSync(path.resolve(EXEC_DIR, `src/config/config.json`), 'utf8');
+  let envFileContents = fs.readFileSync(path.resolve(__dirname, `node_modules/${LIBRARY_NAME}/env.json`), 'utf8');
+  let projectEnvFileContents = fs.readFileSync(path.resolve(__dirname, `src/config/config.json`), 'utf8');
   envFileContents = JSON.parse(envFileContents);
   projectEnvFileContents = JSON.parse(projectEnvFileContents);
 
@@ -21,7 +20,7 @@ const initEnv = async () => {
     projectEnvFileContents[configKey] = envFileContents;
   }
 
-  fs.writeFileSync(path.resolve(EXEC_DIR, `src/config/config.json`), JSON.stringify(projectEnvFileContents, null, 2), 'utf8');
+  fs.writeFileSync(path.resolve(__dirname, `src/config/config.json`), JSON.stringify(projectEnvFileContents, null, 2), 'utf8');
 }
 
 initEnv();


### PR DESCRIPTION
If the njs2 project is inside a directory in your FS with a white spaces on it, the $INIT_CWD doest consider it well.

for e.g.: if your project is at `/Users/<username>/Desktop/JuegoProjects/2.5 USP Rummy/0.0 Sourcecode/usp-server-tigerplatform`
then you will get error on npm i like below
`Error: ENOENT: no such file or directory, open '/Users/<username>/Desktop/JuegoProjects/2.5/node_modules/@njs2/sql/env.json'`