### PR TITLE
Path Resolution issue in postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "sequelize": "^6.3.5"
   },
   "scripts": {
-    "postinstall": "node ./postinstall.js --init-dir $INIT_CWD"
+    "postinstall": "node ./postinstall.js --init-dir \"$INIT_CWD\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
If the njs2 project is inside a directory in your FS with a white spaces on it, the $INIT_CWD doest consider it well.

for e.g.: if your project is at `/Users/<username>/Desktop/JuegoProjects/2.5 USP Rummy/0.0 Sourcecode/usp-server-tigerplatform`
then you will get error on npm i like below
`Error: ENOENT: no such file or directory, open '/Users/<username>/Desktop/JuegoProjects/2.5/node_modules/@njs2/sql/env.json'`